### PR TITLE
ci: updates actions/setup-python and caching mechansim

### DIFF
--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -14,13 +14,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         #os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-        - os: ubuntu-latest
-          path: ~/.cache/pip
-        - os: macos-latest
-          path: ~/Library/Caches/pip
-        # - os: windows-latest
-        #   path: ~\AppData\Local\pip\Cache
         python-version: [3.8, 3.9]
     steps:
     - name: Don't mess with line endings
@@ -30,15 +23,11 @@ jobs:
       with:
         submodules: true
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
-      with:
-        path: ${{ matrix.path }}
-        key: ${{ matrix.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
-        restore-keys: |
-         ${{ matrix.os }}-${{ matrix.python-version }}-pip-
+        cache: "pip"
+        cache-dependency-path: setup.cfg
 
     - name: Install build tools
       run: |
@@ -87,7 +76,7 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.ADMIN_PAT }} 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install build tools

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -23,15 +23,11 @@ jobs:
       with:
         submodules: true
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ubuntu-latest-3.9-pip-${{ hashFiles('setup.cfg') }}
-        restore-keys: |
-          ubuntu-latest-3.9-pip-
+        cache: 'pip'
+        cache-dependency-path: setup.cfg
     - name: Install build tools
       run: |
         make develop
@@ -69,16 +65,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.9
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ubuntu-latest-3.9-pip-${{ hashFiles('setup.cfg') }}
-        restore-keys: |
-          ubuntu-latest-3.9-pip-
+        cache: 'pip'
+        cache-dependency-path: setup.cfg
     - name: Install build tools
       run: |
         make develop
@@ -93,13 +84,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         #os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-        - os: ubuntu-latest
-          path: ~/.cache/pip
-        - os: macos-latest
-          path: ~/Library/Caches/pip
-        # - os: windows-latest
-        #   path: ~\AppData\Local\pip\Cache
         python-version: [3.8, 3.9]
     steps:
     - name: Don't mess with line endings
@@ -110,16 +94,11 @@ jobs:
         fetch-depth: 0
         submodules: true
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
-      with:
-        path: ${{ matrix.path }}
-        key: ${{ matrix.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}
-        restore-keys: |
-         ${{ matrix.os }}-${{ matrix.python-version }}-pip-
-        
+        cache: "pip"
+        cache-dependency-path: setup.cfg
     - name: Install build tools
       run: |
         make develop
@@ -154,15 +133,11 @@ jobs:
       with:
         submodules: true
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ubuntu-latest-3.9-pip-${{ hashFiles('setup.cfg') }}
-        restore-keys: |
-          ubuntu-latest-3.9-pip-
+        cache: 'pip'
+        cache-dependency-path: setup.cfg
     - name: Install build tools
       run: |
         make develop


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue) (**CI only**)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Summary

Older versions of python 3.8 are being installed when not in local cache due to an older version manifest
Related to CI seen in #38 

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle-fedramp)
