### PR TITLE
chore(deps): bump trestle version to major version 3

### DIFF
--- a/.github/workflows/python-push.yml
+++ b/.github/workflows/python-push.yml
@@ -21,7 +21,7 @@ jobs:
           path: ~/Library/Caches/pip
         # - os: windows-latest
         #   path: ~\AppData\Local\pip\Cache
-        python-version: [3.8, 3.9]
+        python-version: [3.9, 3.11]
     steps:
     - name: Don't mess with line endings
       run: |
@@ -44,35 +44,35 @@ jobs:
       run: |
         make develop
     - name: Setup pre-commit
-      if: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8') }}
+      if: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9') }}
       run: |
         make pre-commit
     - name: Install dependencies
       run: |
         make install
     - name: Run md document formatting (mdformat)
-      if: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8') }}
+      if: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9') }}
       run: |
         make mdformat
     - name: Run code formatting (yapf)
-      if: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8') }}
+      if: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9') }}
       run: |
         make code-format
     - name: Run code linting (flake8)
-      if: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8') }}
+      if: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9') }}
       run: |
         make code-lint
     - name: Run code typing check (mypy)
-      if: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8') }}
+      if: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9') }}
       continue-on-error: true 
       run: |
         make code-typing
     - name: Pytest Fast
-      if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8') }}
+      if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9') }}
       run: |
         make test
     - name: Pytest Cov
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' }}
       run: |
         make test-cov
 
@@ -86,10 +86,10 @@ jobs:
         submodules: true
         fetch-depth: 0
         token: ${{ secrets.ADMIN_PAT }} 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install build tools
       run: |
         make develop

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -100,7 +100,7 @@ jobs:
           path: ~/Library/Caches/pip
         # - os: windows-latest
         #   path: ~\AppData\Local\pip\Cache
-        python-version: [3.8, 3.9]
+        python-version: [3.9, 3.11]
     steps:
     - name: Don't mess with line endings
       run: |
@@ -124,16 +124,16 @@ jobs:
       run: |
         make develop
     - name: Pytest Fast
-      if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8') }}
+      if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9') }}
       run: |
         make test
     - name: Pytest Cov
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' }}
       run: |
         make test-cov
 
     - name: Upload artifact
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' }}
       uses: actions/upload-artifact@v2
       with:
         name: coverage
@@ -156,7 +156,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip
@@ -180,7 +180,7 @@ jobs:
           -Dsonar.python.coverage.reportPaths=coverage.xml
           -Dsonar.tests=tests/
           -Dsonar.sources=trestle_fedramp/ 
-          -Dsonar.python.version=3.8
+          -Dsonar.python.version=3.9
           -Dsonar.projectKey=compliance-trestle-fedramp
           -Dsonar.organization=compliance-trestle
     - name: SonarQube Quality Gate check

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,11 +15,12 @@ classifiers =
     Operating System :: POSIX
     Operating System :: Microsoft
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 long_description_content_type = text/markdown
 long_description = file: README.md
-python_require= '>=3.8'
+python_require= '>=3.9'
 [options]
 packages = find:
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages = find:
 include_package_data = True
 
 install_requires =
-    compliance-trestle>=2.5.1
+    compliance-trestle>=3.3.0
     saxonche>=12.4.1.0
 
 [options.packages.find]

--- a/trestle_fedramp/core/fedramp.py
+++ b/trestle_fedramp/core/fedramp.py
@@ -17,8 +17,7 @@ import logging
 import pathlib
 import sys
 import tempfile
-
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from saxonche import (PySaxonApiError, PySaxonProcessor, PyXslt30Processor)
 
@@ -37,21 +36,18 @@ class FedrampValidator:
 
     def __init__(self):
         """Intialize FedRAMP validator."""
-        self.baselines_path = pathlib.Path(resource_filename('trestle_fedramp.resources',
-                                                             const.FEDRAM_BASELINE)).resolve()
+        self.baselines_path = files('trestle_fedramp.resources').joinpath(const.FEDRAM_BASELINE)
+
         if not self.baselines_path.exists():
             raise TrestleError(f'Fedramp baseline directory {self.baselines_path} does not exist')
 
-        self.registry_path = pathlib.Path(resource_filename('trestle_fedramp.resources',
-                                                            const.FEDRAMP_REGISTRY)).resolve()
+        self.registry_path = files('trestle_fedramp.resources').joinpath(const.FEDRAMP_REGISTRY)
         if not self.registry_path.exists():
             raise TrestleError(f'Fedramp registry directory {self.registry_path} does not exist')
 
-        self.ssp_xsl_path = pathlib.Path(resource_filename('trestle_fedramp.resources',
-                                                           const.FEDRAMP_SSP_XSL)).resolve()
+        self.ssp_xsl_path = files('trestle_fedramp.resources').joinpath(const.FEDRAMP_SSP_XSL)
 
-        self.svrl_xsl_path = pathlib.Path(resource_filename('trestle_fedramp.resources',
-                                                            const.FEDRAM__SVRL_XSL)).resolve()
+        self.svrl_xsl_path = files('trestle_fedramp.resources').joinpath(const.FEDRAM__SVRL_XSL)
 
         logger.debug(f'Baselines dir: {self.baselines_path}')
         logger.debug(f'Registry dir: {self.registry_path}')

--- a/trestle_fedramp/core/format_convert.py
+++ b/trestle_fedramp/core/format_convert.py
@@ -15,10 +15,8 @@
 
 import base64
 import logging
-import pathlib
 import sys
-
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from saxonche import PySaxonProcessor
 
@@ -36,9 +34,7 @@ class JsonXmlConverter:
 
     def __init__(self):
         """Initialize JSON to XML converter."""
-        self.ssp_j_x_xsl_path = pathlib.Path(
-            resource_filename('trestle_fedramp.resources', const.NIST_SSP_JSON_XML_XSL)
-        ).resolve()
+        self.ssp_j_x_xsl_path = files('trestle_fedramp.resources').joinpath(const.NIST_SSP_JSON_XML_XSL)
         logger.info(f'SSP converter from JSON to XML: {self.ssp_j_x_xsl_path}')
 
         self.initial_template = const.NIST_INITIAL_TEMPLATE


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Summary

The following change updates the plugin to use the latest major version of `compliance-trestle`. It includes:

- Dropping support for 3.8. Adding support for 3.10 and 3.11 to match `trestle`
- Replacing the use of `pkg_resources`, deprecated in 3.11

Closes #42 

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle-fedramp)
