### PR TITLE
fix: updates sonar job so it does not run on dependabot PRs

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -140,7 +140,7 @@ jobs:
         path: coverage.xml
 
   sonar:
-    if: github.repository == 'oscal-compass/compliance-trestle-fedramp'
+    if: ${{ (github.event.pull_request.base.repo.url == github.event.pull_request.head.repo.url && github.triggering_actor != 'dependabot[bot]' ) }}
     runs-on: ubuntu-latest
     needs: test
     steps:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Summary

Updates `sonar` CI to ensure it does not run when the PR is from Dependabot

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle-fedramp)
